### PR TITLE
Weaken test for rgl 0.100.x compatibility

### DIFF
--- a/tests/testthat/test-loadobj.R
+++ b/tests/testthat/test-loadobj.R
@@ -18,6 +18,12 @@ test_that("can convert to rgl format", {
     cube=readRDS("testdata/cube.rds")
     cubesl_baseline=readRDS("testdata/cubesl.rds")
     expect_is(cubesl <- tinyobj2shapelist3d(cube), 'shapelist3d')
+    # rgl dropped the "primitivetype" component in version 0.100.x
+    # Ignore it in the tests so we work with both old and new rgl
+    for (side in c("front", "back", "right", "left", "top", "bottom")) {
+      cubesl[[side]]$primitivetype <-
+        cubesl_baseline[[side]]$primitivetype <- NULL
+    }
     expect_equal(cubesl, cubesl_baseline)
   }
 })


### PR DESCRIPTION
rgl 0.100.x dropped the `primitivetype` component from `mesh3d` objects.  This patch sets it to `NULL` so it will be ignored in the tests.

I've been asked to update rgl soon (CRAN found some PROTECT issues), so this will likely become a problem within a few days.