### PR TITLE
Don't worry about the difference between NULL and not present.

### DIFF
--- a/tests/testthat/test-loadobj.R
+++ b/tests/testthat/test-loadobj.R
@@ -19,13 +19,26 @@ test_that("can load an obj file", {
   expect_equal(tile, tile_baseline)
 })
 
+removeNULLs <- function(x) {
+  for (i in seq_along(x))
+    for (n in names(x[[i]]))
+      if (is.null(x[[i]][[n]]))
+        x[[i]][[n]] <- NULL
+  x
+}
+
 test_that("can convert to rgl format", {
   if(require('rgl', quietly = TRUE)){
     cube=readRDS("testdata/cube.rds")
     cubesl_baseline=readRDS("testdata/cubesl.rds")
+    cubesl_baseline <- removeNULLs(cubesl_baseline)
     expect_is(cubesl <- tinyobj2shapelist3d(cube), 'shapelist3d')
+    cubesl <- removeNULLs(cubesl)
     # rgl dropped the "primitivetype" component in version 0.100.x
     # Ignore it in the tests so we work with both old and new rgl
+    # In the upcoming release of rgl mesh objects contain more
+    # components (points, line segments are the main changes).
+    # Remove these if NULL.
     for (side in c("front", "back", "right", "left", "top", "bottom")) {
       cubesl[[side]]$primitivetype <-
         cubesl_baseline[[side]]$primitivetype <- NULL
@@ -34,13 +47,15 @@ test_that("can convert to rgl format", {
 
     tile=readRDS("testdata/tile.rds")
     expect_is(tilesl <- tinyobj2shapelist3d(tile), 'shapelist3d')
+    tilesl <- removeNULLs(tilesl)
     # texture=system.file("obj/tile.png", package="readobj")
     # shade3d(tilesl, material=list(texture=texture, color="white"))
     # saveRDS(tilesl, file='testdata/tilesl.rds')
     tilesl_baseline=readRDS("testdata/tilesl.rds")
-    for (side in c("front", "back", "right", "left", "top", "bottom")) {
-      tilesl[[side]]$primitivetype <-
-        tilesl_baseline[[side]]$primitivetype <- NULL
+    tilesl_baseline <- removeNULLs(tilesl_baseline)
+    for (s in seq_along(tilesl)) {
+      tilesl[[s]]$primitivetype <-
+        tilesl_baseline[[s]]$primitivetype <- NULL
     }
     expect_equal(tilesl, tilesl_baseline)
   }


### PR DESCRIPTION
Recent (unpublished) changes to rgl are breaking the tests for readobj.  I am not sure of the exact source, but the two cases I looked at are both of the form where a mesh object contains a component which is `NULL` in the new version of the object and missing in the old one (or vice versa).

The attached change to the test code ignores that kind of difference, and `readobj` tests pass now for me.  I think this is a reasonable thing to ignore, but maybe you'd want to track down where the NULLs are coming from.  Some of this is doubtless in rgl, where I have recently done a lot of changes to the mesh code.   If those NULLs are really causing trouble for you, I'll see if I can get rid of them.

